### PR TITLE
Remove ring group interface challenge link

### DIFF
--- a/problems/README.md
+++ b/problems/README.md
@@ -35,7 +35,6 @@ into pure stealth mode. You can reach us via [hipchat](http://www.hipchat.com/gP
 ### Frontend
 
 - [SMS Support on Talkdesk](f1_sms_support.md)
-- [Ring Groups Interface](f2_ring_groups.md)
 - [Visual Representation of In Progress Calls](f3_visual_representation_of_calls.md)
 - [Browser Telephone](f4_browser_phone.md)
 


### PR DESCRIPTION
A while ago we removed the ring group interface challenge from the
repository but failed to remove the link from the problems list

Fixes #42